### PR TITLE
chore(release): 0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "minecraft-smp",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"description": "A lightweight, full-featured TypeScript library for the Minecraft Server Management Protocol",
 	"main": "./dist/index.js",
 	"module": "dist/index.js",


### PR DESCRIPTION
This pull request bumps minecraft-smp from **0.0.2** to **0.0.3**.